### PR TITLE
Fix critical LAMMPS PAIR-NN bug

### DIFF
--- a/simple_nn/features/symmetry_function/pair_nn.cpp
+++ b/simple_nn/features/symmetry_function/pair_nn.cpp
@@ -451,6 +451,7 @@ void PairNN::read_file(char *fname) {
       double t_cut = atof(strtok(NULL," \t\n\r\f"));
       if (t_cut > cutmax) cutmax = t_cut;
       int slen = strlen(t_elem);
+      nnet = nelements;
       for (i=0; i<nelements; i++) {
         if (strncmp(t_elem,elements[i],slen) == 0) {
           nnet = i;


### PR DESCRIPTION
* Fixed critical LAMMPS PAIR-NN bug where if you use, for example, Si/Ni
potential on Si only system (1 atom type), Si potential is overwritten
by Ni potential.

The initial value of `nnet` (`=nelements`) was assigned once. It needs to be reassigned for every element we read.