### PR TITLE
Fix not to modify input dictionary

### DIFF
--- a/simple_nn/models/neural_network.py
+++ b/simple_nn/models/neural_network.py
@@ -189,8 +189,9 @@ class Neural_network(object):
                                                                 options=self.inputs['optimizer'])
         elif self.inputs['method'] == 'Adam':
             if isinstance(self.inputs['learning_rate'], collections.Mapping):
-                self.inputs['learning_rate']['learning_rate'] = tf.constant(self.inputs['learning_rate']['learning_rate'], tf.float64)
-                self.learning_rate = tf.train.exponential_decay(global_step=self.global_step, **self.inputs['learning_rate'])
+                exponential_decay_inputs = copy.deepcopy(self.inputs['learning_rate'])
+                exponential_decay_inputs['learning_rate'] = tf.constant(exponential_decay_inputs['learning_rate'], tf.float64)
+                self.learning_rate = tf.train.exponential_decay(global_step=self.global_step, **exponential_decay_inputs)
             else:
                 self.learning_rate = tf.constant(self.inputs['learning_rate'], tf.float64)
 


### PR DESCRIPTION
A YAML serialization error occurred when using exponential decaying learning rate since the type of `self.inputs['learning_rate']['learning_rate']` had changed to` tf.Tensor` from python `float`. This PR fixes the problem.