### PR TITLE
G5

### DIFF
--- a/simple_nn/features/symmetry_function/__init__.py
+++ b/simple_nn/features/symmetry_function/__init__.py
@@ -447,6 +447,8 @@ class Symmetry_function(object):
                     comm.barrier()
                     if errno == 1:
                         raise NotImplementedError("Not implemented symmetry function type!")
+                    elif errno == 2:
+                        raise ValueError("Zeta in G4/G5 must be integer!")
                     else:
                         assert errno == 0
 

--- a/simple_nn/features/symmetry_function/__init__.py
+++ b/simple_nn/features/symmetry_function/__init__.py
@@ -337,10 +337,10 @@ class Symmetry_function(object):
             comm = DummyMPI()
 
         ffi = FFI()
-        ffi.cdef("""void calculate_sf(double **, double **, double **,
-                                      int *, int, int*, int,
-                                      int**, double **, int, 
-                                      double**, double**);""")
+        ffi.cdef("""int calculate_sf(double **, double **, double **,
+                                     int *, int, int*, int,
+                                     int**, double **, int, 
+                                     double**, double**);""")
         lib = ffi.dlopen(os.path.join(os.path.dirname(os.path.realpath(__file__)) + "/libsymf.so"))
 
         if comm.rank == 0:
@@ -440,11 +440,15 @@ class Symmetry_function(object):
                     x_p = _gen_2Darray_for_ffi(x, ffi)
                     dx_p = _gen_2Darray_for_ffi(dx, ffi)
 
-                    lib.calculate_sf(cell_p, cart_p, scale_p, \
+                    errno = lib.calculate_sf(cell_p, cart_p, scale_p, \
                                      atom_i_p, atom_num, cal_atoms_p, cal_num, \
                                      params_set[jtem]['ip'], params_set[jtem]['dp'], params_set[jtem]['num'], \
                                      x_p, dx_p)
                     comm.barrier()
+                    if errno == 1:
+                        raise NotImplementedError("Not implemented symmetry function type!")
+                    else:
+                        assert errno == 0
 
 
                     if comm.rank == 0:

--- a/simple_nn/features/symmetry_function/calculate_sf.cpp
+++ b/simple_nn/features/symmetry_function/calculate_sf.cpp
@@ -3,10 +3,10 @@
 #include <stdio.h>
 #include "calculate_sf.h"
 
-extern "C" void calculate_sf(double** cell, double** cart, double** scale,
-                             int* atom_i, int natoms, int* cal_atoms, int cal_num,
-                             int** params_i, double** params_d, int nsyms,
-                             double** symf, double** dsymf) {
+extern "C" int calculate_sf(double** cell, double** cart, double** scale,
+                            int* atom_i, int natoms, int* cal_atoms, int cal_num,
+                            int** params_i, double** params_d, int nsyms,
+                            double** symf, double** dsymf) {
     // cell: cell info of structure
     // cart: cartesian coordinates of atoms
     // scale: fractional coordinates of atoms
@@ -29,6 +29,18 @@ extern "C" void calculate_sf(double** cell, double** cart, double** scale,
     double plane_d[3], total_shift[3], precal[12], tmpd[9], dangtmp[3];
     double vecij[3], vecik[3], vecjk[3], deljk[3];
     double cross[3][3], reci[3][3];//, powtwo[nsyms];
+
+    // Check for not implemented symfunc type.
+    for (int s=0; s < nsyms; ++s) {
+        bool implemented = false;
+        for (int i=0; i < sizeof(IMPLEMENTED_TYPE) / sizeof(IMPLEMENTED_TYPE[0]); i++) {
+            if (params_i[s][0] == IMPLEMENTED_TYPE[i]) {
+                implemented = true;
+                break;
+            }
+        }
+        if (!implemented) return 1;
+    }
 
     int **bin_i = new int*[natoms];
     for (int i=0; i<natoms; i++) {
@@ -285,6 +297,7 @@ extern "C" void calculate_sf(double** cell, double** cart, double** scale,
     }
     delete[] bin_i;
     delete[] powtwo;
+    return 0;
 }
 
 void PyInit_libsymf(void) { } // for windows

--- a/simple_nn/features/symmetry_function/calculate_sf.cpp
+++ b/simple_nn/features/symmetry_function/calculate_sf.cpp
@@ -219,8 +219,8 @@ extern "C" int calculate_sf(double** cell, double** cart, double** scale,
 
                 for (int s=0; s < nsyms; ++s) {
                     if ((params_i[s][0] == 4) && 
-                        ((params_i[s][1] == nei_list_i[j*2]) && (params_i[s][2] == nei_list_i[k*2])) || 
-                        ((params_i[s][1] == nei_list_i[k*2]) && (params_i[s][2] == nei_list_i[j*2]))  ) { // FIXME:
+                       (((params_i[s][1] == nei_list_i[j*2]) && (params_i[s][2] == nei_list_i[k*2])) || 
+                        ((params_i[s][1] == nei_list_i[k*2]) && (params_i[s][2] == nei_list_i[j*2]))) ) { // FIXME:
 
                         precal[0] = cutf(rRij / params_d[s][0]);
                         precal[1] = dcutf(rRij, params_d[s][0]);
@@ -254,8 +254,8 @@ extern "C" int calculate_sf(double** cell, double** cart, double** scale,
                         dsymf[ii][s*natoms*3 + i*3 + 2] -= tmpd[2] + tmpd[5];
                     }
                     else if ((params_i[s][0] == 5) &&
-                            ((params_i[s][1] == nei_list_i[j*2]) && (params_i[s][2] == nei_list_i[k*2])) ||
-                            ((params_i[s][1] == nei_list_i[k*2]) && (params_i[s][2] == nei_list_i[j*2]))  ) {
+                           (((params_i[s][1] == nei_list_i[j*2]) && (params_i[s][2] == nei_list_i[k*2])) ||
+                            ((params_i[s][1] == nei_list_i[k*2]) && (params_i[s][2] == nei_list_i[j*2]))) ) {
 
                         precal[0] = cutf(rRij / params_d[s][0]);
                         precal[1] = dcutf(rRij, params_d[s][0]);

--- a/simple_nn/features/symmetry_function/calculate_sf.cpp
+++ b/simple_nn/features/symmetry_function/calculate_sf.cpp
@@ -53,6 +53,9 @@ extern "C" int calculate_sf(double** cell, double** cart, double** scale,
     for (int s=0; s < nsyms; ++s) {
         if (cutoff < params_d[s][0])
             cutoff = params_d[s][0];
+        if ((params_i[s][0] == 4 || params_i[s][0] == 5) &&
+             ceilf(params_d[s][2]) != params_d[s][2])
+            return 2;
         powtwo[s] = pow_int(2, 1.-params_d[s][2]);
     }
     

--- a/simple_nn/features/symmetry_function/calculate_sf.h
+++ b/simple_nn/features/symmetry_function/calculate_sf.h
@@ -8,7 +8,7 @@
 //#include "mpi.h"
 #include "symmetry_functions.h"
 
-extern "C" void calculate_sf(double **, double **, double **,
-                             int *, int, int*, int,
-                             int**, double **, int, 
-                             double**, double**);
+extern "C" int calculate_sf(double **, double **, double **,
+                            int *, int, int*, int,
+                            int**, double **, int, 
+                            double**, double**);

--- a/simple_nn/features/symmetry_function/pair_nn.cpp
+++ b/simple_nn/features/symmetry_function/pair_nn.cpp
@@ -115,6 +115,20 @@ void PairNN::compute(int eflag, int vflag)
     jnum = numneigh[i];
     int numshort = 0;
     nsym = nets[ielem].nnode[0];
+
+    // Check for not implemented symfunc type.
+    for (tt=0; tt<nsym; tt++) {
+        bool implemented = false;
+        sym = &nets[ielem].slists[tt];
+        for (int i=0; i < sizeof(IMPLEMENTED_TYPE) / sizeof(IMPLEMENTED_TYPE[0]); i++) {
+            if ((sym->stype) == IMPLEMENTED_TYPE[i]) {
+                implemented = true;
+                break;
+            }
+        }
+        if (!implemented) error->all(FLERR, "Not implemented symmetry function type!");
+    }
+
     
     double *symvec = new double[nsym];
     double *dsymvec = new double[nsym];
@@ -133,7 +147,7 @@ void PairNN::compute(int eflag, int vflag)
       dsymvec[tt] = 0;
       powtwo[tt] = 0;
 
-      if (nets[ielem].slists[tt].stype == 4)
+      if (nets[ielem].slists[tt].stype == 4 || nets[ielem].slists[tt].stype == 5)
         powtwo[tt] = powint(2, 1-nets[ielem].slists[tt].coefs[2]);
     }
 

--- a/simple_nn/features/symmetry_function/pair_nn.cpp
+++ b/simple_nn/features/symmetry_function/pair_nn.cpp
@@ -77,7 +77,7 @@ void PairNN::compute(int eflag, int vflag)
   double xtmp,ytmp,ztmp,evdwl,fpair,dradtmp,tmpc,tmpE;
   double dangtmp[3];
   double tmpd[9];
-  double precal[11];
+  double precal[12];
   // precal: cfij, dcfij, cfik, dcfik, cfjk, dcfjk, dist_square_sum,
   //         cosval, dcosval/dij, dcosval/dik, dcosval/djk
   double delij[3],delik[3],deljk[3],vecij[3],vecik[3],vecjk[3];
@@ -220,6 +220,7 @@ void PairNN::compute(int eflag, int vflag)
         precal[8] = 0.5*(1/rRik + 1/rRij/rRij*(rRjk*rRjk/rRik - rRik));
         precal[9] = 0.5*(1/rRij + 1/rRik/rRik*(rRjk*rRjk/rRij - rRij));
         precal[10] = rRjk/rRij/rRik;
+        precal[11] = rRij*rRij+rRik*rRik;
 
         // calc angular symfunc
         for (tt=0; tt<nsym; tt++) {
@@ -254,6 +255,38 @@ void PairNN::compute(int eflag, int vflag)
             tmpf[tt*(jnum+1)*3 + kk*3 + 1] += tmpd[4] + tmpd[7];
             tmpf[tt*(jnum+1)*3 + kk*3 + 2] += tmpd[5] + tmpd[8];
        
+            tmpf[tt*(jnum+1)*3 + jnum*3 + 0] -= tmpd[0] + tmpd[3];
+            tmpf[tt*(jnum+1)*3 + jnum*3 + 1] -= tmpd[1] + tmpd[4];
+            tmpf[tt*(jnum+1)*3 + jnum*3 + 2] -= tmpd[2] + tmpd[5];
+          }
+          else if ((sym->stype) == 5 && \
+              ((sym->atype[0] == jelem && sym->atype[1] == kelem) || \
+               (sym->atype[0] == kelem && sym->atype[1] == jelem))) {
+            precal[0] = cutf(rRij/nets[ielem].slists[tt].coefs[0]);
+            precal[1] = dcutf(rRij, nets[ielem].slists[tt].coefs[0]);
+            precal[2] = cutf(rRik/nets[ielem].slists[tt].coefs[0]);
+            precal[3] = dcutf(rRik, nets[ielem].slists[tt].coefs[0]);
+
+            symvec[tt] += G5(rRij, rRik, powtwo[tt], precal, sym->coefs, dangtmp);
+
+            tmpd[0] = dangtmp[0]*vecij[0];
+            tmpd[1] = dangtmp[0]*vecij[1];
+            tmpd[2] = dangtmp[0]*vecij[2];
+            tmpd[3] = dangtmp[1]*vecik[0];
+            tmpd[4] = dangtmp[1]*vecik[1];
+            tmpd[5] = dangtmp[1]*vecik[2];
+            tmpd[6] = dangtmp[2]*vecjk[0];
+            tmpd[7] = dangtmp[2]*vecjk[1];
+            tmpd[8] = dangtmp[2]*vecjk[2];
+
+            tmpf[tt*(jnum+1)*3 + jj*3 + 0] += tmpd[0] - tmpd[6];
+            tmpf[tt*(jnum+1)*3 + jj*3 + 1] += tmpd[1] - tmpd[7];
+            tmpf[tt*(jnum+1)*3 + jj*3 + 2] += tmpd[2] - tmpd[8];
+
+            tmpf[tt*(jnum+1)*3 + kk*3 + 0] += tmpd[3] + tmpd[6];
+            tmpf[tt*(jnum+1)*3 + kk*3 + 1] += tmpd[4] + tmpd[7];
+            tmpf[tt*(jnum+1)*3 + kk*3 + 2] += tmpd[5] + tmpd[8];
+
             tmpf[tt*(jnum+1)*3 + jnum*3 + 0] -= tmpd[0] + tmpd[3];
             tmpf[tt*(jnum+1)*3 + jnum*3 + 1] -= tmpd[1] + tmpd[4];
             tmpf[tt*(jnum+1)*3 + jnum*3 + 2] -= tmpd[2] + tmpd[5];

--- a/simple_nn/features/symmetry_function/pair_nn.cpp
+++ b/simple_nn/features/symmetry_function/pair_nn.cpp
@@ -218,8 +218,7 @@ void PairNN::compute(int eflag, int vflag)
         Rjk = deljk[0]*deljk[0] + deljk[1]*deljk[1] + deljk[2]*deljk[2];
         rRjk = sqrt(Rjk);
 
-        if (Rjk < 0.0001 || Rik < 0.0001 || \
-            Rik > cutsq[itype][ktype] || Rjk > cutsq[itype][jtype]) { continue; }
+        if (Rjk < 0.0001 || Rik < 0.0001 || Rik > cutsq[itype][ktype]) continue;
         
         vecik[0] = delik[0]/rRik;
         vecik[1] = delik[1]/rRik;
@@ -244,6 +243,7 @@ void PairNN::compute(int eflag, int vflag)
           if ((sym->stype) == 4 && \
               ((sym->atype[0] == jelem && sym->atype[1] == kelem) || \
                (sym->atype[0] == kelem && sym->atype[1] == jelem))) {
+            if (Rjk > cutsq[itype][jtype]) continue;
             precal[0] = cutf(rRij/nets[ielem].slists[tt].coefs[0]);
             precal[1] = dcutf(rRij, nets[ielem].slists[tt].coefs[0]);
             precal[2] = cutf(rRik/nets[ielem].slists[tt].coefs[0]);

--- a/simple_nn/features/symmetry_function/pair_nn.cpp
+++ b/simple_nn/features/symmetry_function/pair_nn.cpp
@@ -148,6 +148,8 @@ void PairNN::compute(int eflag, int vflag)
       powtwo[tt] = 0;
 
       if (nets[ielem].slists[tt].stype == 4 || nets[ielem].slists[tt].stype == 5)
+        if (ceilf(nets[ielem].slists[tt].coefs[2]) != nets[ielem].slists[tt].coefs[2])
+            error->all(FLERR, "Zeta in G4/G5 must be integer!");
         powtwo[tt] = powint(2, 1-nets[ielem].slists[tt].coefs[2]);
     }
 

--- a/simple_nn/features/symmetry_function/symmetry_functions.cpp
+++ b/simple_nn/features/symmetry_function/symmetry_functions.cpp
@@ -40,7 +40,7 @@ double G4(double Rij, double Rik, double Rjk, double powtwo, \
     // cosv: cos(theta)
     // par[0] = cutoff_dist
     // par[1] = eta
-    // par[2] = xi
+    // par[2] = zeta
     // par[3] = lambda
     double expl = exp(-par[1]*precal[6]) * powtwo;
     double cosv = 1 + par[3]*precal[7];
@@ -57,4 +57,27 @@ double G4(double Rij, double Rik, double Rjk, double powtwo, \
                par[2]*par[3]*precal[4]*precal[10]); // jk
 
     return powcos*cosv * expl * precal[0] * precal[2] * precal[4];
+}
+
+double G5(double Rij, double Rik, double powtwo, \
+          double *precal, double *par, double *deriv) {
+    // cosv: cos(theta)
+    // par[0] = cutoff_dist
+    // par[1] = eta
+    // par[2] = zeta
+    // par[3] = lambda
+    double expl = exp(-par[1]*precal[11]) * powtwo;
+    double cosv = 1 + par[3]*precal[7];
+    double powcos = pow_int(cosv, par[2]-1);
+
+    deriv[0] = expl*powcos*precal[2] * \
+               ((-2*par[1]*Rij*precal[0] + precal[1])*cosv + \
+               par[2]*par[3]*precal[0]*precal[8]); // ij
+    deriv[1] = expl*powcos*precal[0] * \
+               ((-2*par[1]*Rik*precal[2] + precal[3])*cosv + \
+               par[2]*par[3]*precal[2]*precal[9]); // ik
+    deriv[2] = expl*powcos*precal[0]*precal[2] * \
+               -par[2]*par[3]*precal[10]; // jk
+
+    return powcos*cosv * expl * precal[0] * precal[2];
 }

--- a/simple_nn/features/symmetry_function/symmetry_functions.h
+++ b/simple_nn/features/symmetry_function/symmetry_functions.h
@@ -21,3 +21,4 @@ double cutf(double);
 double dcutf(double, double);
 double G2(double, double *, double *, double &);
 double G4(double, double, double, double, double *, double *, double *);
+double G5(double, double, double, double *, double *, double *);

--- a/simple_nn/features/symmetry_function/symmetry_functions.h
+++ b/simple_nn/features/symmetry_function/symmetry_functions.h
@@ -2,6 +2,7 @@
  Code for calculate symmetry function.
  This code is used for both Python and LAMMPS code
  */
+const int IMPLEMENTED_TYPE[] = {2, 4, 5}; // Change this when you implement new symfunc type!
 
 static inline double pow_int(const double &x, const double n) {
     double res,tmp;


### PR DESCRIPTION
* G5 symmetry function is implemented.

* `calculate_sf` now returns error code (and PAIR-NN prints error messages):
1: Invalid symmetry function type.
2: Zeta in G4/G5 is not integer.

* Fixed a bug in conditional statement.