### PR TITLE
add early stop properties

### DIFF
--- a/simple_nn/models/neural_network.py
+++ b/simple_nn/models/neural_network.py
@@ -660,13 +660,17 @@ class Neural_network(object):
                             prev_floss = floss
                             save_stack = 1
                             save_time = timeit.default_timer() - temp_time
+                            if break_tag:
+                                break_count = 1
                         else:
                             save_time = 0
-                            break_count += 1
+                            if break_tag:
+                                break_count += 1
 
                     # Stop the training if overfitting is occur
-                    if (break_count > self.inputs['break_max']):
-                        break
+                    if break_tag:
+                        if (break_count > self.inputs['break_max']):
+                            break
                 #self._save(sess, saver)
                 
 

--- a/simple_nn/models/neural_network.py
+++ b/simple_nn/models/neural_network.py
@@ -56,6 +56,7 @@ class Neural_network(object):
                                       'stddev': 0.3,
                                       'echeck': True,
                                       'fcheck': True,
+                                      'break_max': 10,
                                   }
                               }
         self.inputs = dict()
@@ -539,7 +540,16 @@ class Neural_network(object):
                 time1 = timeit.default_timer()
                 save_time = 0
 
-                for epoch in range(self.inputs['total_epoch']):
+                if self.inputs['total_epoch'] < 0:
+                    total_epoch = -self.inputs['total_epoch']
+                    break_tag = True
+                    break_count = 1
+                    break_max = self.inputs['break_max']
+                else:
+                    total_epoch = self.inputs['total_epoch']
+                    break_tag = False
+
+                for epoch in range(total_epoch):
                     if self.inputs['full_batch']:
                         if self.inputs['method'] == 'Adam':
                             [flat_grad] = self._get_full_batch_values(sess, train_iter, train_fdict, need_loss=False)
@@ -652,8 +662,13 @@ class Neural_network(object):
                             save_time = timeit.default_timer() - temp_time
                         else:
                             save_time = 0
+                            break_count += 1
 
+                    # Stop the training if overfitting is occur
+                    if (break_count > self.inputs['break_max']):
+                        break
                 #self._save(sess, saver)
+                
 
             if self.inputs['test']:
                 test_handle = sess.run(test_iter.string_handle())


### PR DESCRIPTION
Add early stop properties:
- if total_epoch < 0, early stop mode activates.
- Currently, if validation loss is larger than the previous save point, we do not save in the current state.
  Now, break count is also increased in that point.
- if break_count > break_max(user can set this in input.yaml), then training is stopped.
- if current epoch > |total_epoch|, training is also stopped.