### PR TITLE
ase version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ install_requires = [
 ]
 
 if sys.version_info >= (3,5):
-    install_requires.append('ase>=3.10.0')
+    install_requires.append('ase>=3.10.0,<=3.19.0')
 else:
     install_requires.append('ase>=3.10.0,<3.18.0')
 

--- a/simple_nn/__init__.py
+++ b/simple_nn/__init__.py
@@ -183,10 +183,6 @@ class Simple_nn(object):
 
         if self.inputs['generate_features']:
             self.descriptor.generate()
-            self.descriptor.preprocess(use_force=self.inputs['neural_network']['use_force'],
-                                       use_stress=self.inputs['neural_network']['use_stress'],
-                                       get_atomic_weights=get_atomic_weights,
-                                       **self.descriptor.inputs['atomic_weights']['params'])
         elif self.inputs['preprocess']:
             self.descriptor.preprocess(use_force=self.inputs['neural_network']['use_force'], 
                                        use_stress=self.inputs['neural_network']['use_stress'],


### PR DESCRIPTION
* Only ase <= 3.19.0 has been checked.
* `generate` tag in `input.yaml` does not invoke `preprocess` anymore.