### PR TITLE
position consistenty

### DIFF
--- a/simple_nn/features/symmetry_function/__init__.py
+++ b/simple_nn/features/symmetry_function/__init__.py
@@ -574,9 +574,10 @@ class Symmetry_function(object):
                 snapshots = io.read(item[0], index=index, format=self.inputs['refdata_format'])
 
             for atoms in snapshots:
-                cart = np.copy(atoms.get_positions(wrap=True), order='C')
-                scale = np.copy(atoms.get_scaled_positions(), order='C')
+                # consistency for cart <-> scale
                 cell = np.copy(atoms.cell, order='C')
+                scale = np.copy(atoms.get_scaled_positions(), order='C')
+                cart = np.copy(np.dot(atoms.get_scaled_positions(), atoms.cell), order='C') 
 
                 symbols = np.array(atoms.get_chemical_symbols())
                 atom_num = len(symbols)


### PR DESCRIPTION
When the atom is located near the boundary, `ase` has inconsistency between cartesian and direct.
It causes different symmetry function values even in the perfect bulk.